### PR TITLE
Provides a curl | bash installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ sudo systemctl start docker-syncthing@${INSTANCE_NAME}
 
 Repeat these steps to setup others instances.
 
-## Build image and test
+## Build image
 
 Clone this repository and build the Docker image:
 
@@ -95,7 +95,9 @@ $ cd docker-syncthing
 $ docker build --rm -t nventiveux/docker-syncthing:latest .
 ```
 
-Run it !
+## Manual usage
+
+Run the container manually:
 
 ```shell
 $ docker run \

--- a/README.md
+++ b/README.md
@@ -2,44 +2,104 @@
 
 Syncthing Docker image for RaspberryPi.
 
-## Quick start
+> Syncthing replaces proprietary sync and cloud services with something open, trustworthy and decentralized.
 
-Clone this repository and build the Docker image.
+See [Syncthing](https://syncthing.net/) website for more.
+
+Tested on:
+
+* RaspberryPi 2 (Model B)
+* RaspberryPi 3 (Model B)
+
+**Note**: this is still under heavy development and testing. Feedbacks / Pull requests are welcome !
+
+## Quick install
 
 ```shell
-$ git clone git@ssh.github.com:nVentiveUX/docker-syncthing.git
-$ cd docker-syncthing
-$ docker build --rm -t nventiveux/docker-syncthing:0.14.19 .
+$ curl -sSL https://raw.githubusercontent.com/nVentiveUX/docker-syncthing/master/installer.sh | sudo bash
 ```
 
-Run the container
+* Ensure [Docker Engine](https://www.docker.com/products/overview) is installed.
+* Install as a **systemd service** container stop / start.
+* Install service options in `/etc/default`.
+* Set service start at boot.
+
+## Run multiple instances
+
+Define an instance name, replace `<NAME>` by something suitable for you:
+
+```shell
+$ INSTANCE_NAME="<NAME>"
+```
+
+Setup the new instance as a **systemd service**:
 
 ```shell
 $ {
 sudo cp systemd/docker-syncthing@.service /etc/systemd/system/ &&
-sudo cp systemd/docker-syncthing@.default /etc/default/docker-syncthing@$USER &&
+sudo cp systemd/docker-syncthing@.default /etc/default/docker-syncthing@${INSTANCE_NAME} &&
 sudo systemctl daemon-reload &&
-sudo systemctl enable docker-syncthing@$USER.service;
+sudo systemctl enable docker-syncthing@${INSTANCE_NAME}.service;
 }
 ```
 
-Provide some folder to sync
+Edit instance options:
 
 ```shell
-$ sudo vi /etc/default/docker-syncthing@$USER
+$ sudo vi /etc/default/docker-syncthing@${INSTANCE_NAME}
 ```
 
-Start Syncthing
+Start new instance:
 
 ```shell
-$ {
-sudo systemctl start docker-syncthing@$USER.service &&
-sudo systemctl status -l docker-syncthing@$USER.service;
-}
+$ sudo systemctl start docker-syncthing@${INSTANCE_NAME}
 ```
 
-Open web browser to https://localhost:8384/ (replace `localhost` by your RPi address).
+Repeat these steps to setup others instances.
+
+## Build image and test
+
+Clone this repository and build the Docker image:
+
+```shell
+$ git clone https://github.com/nVentiveUX/docker-syncthing.git
+$ cd docker-syncthing
+$ docker build --rm -t nventiveux/docker-syncthing:latest .
+```
+
+Run it !
+
+```shell
+$ docker run \
+    --rm \
+    --name syncthing \
+    -p 8384:8384 -p 22000:22000 \
+    nventiveux/docker-syncthing:latest
+```
+
+Persist syncthing database and configuration by creating a [volume or data container](https://docs.docker.com/engine/tutorials/dockervolumes/) with:
+
+```shell
+$ docker run \
+    --rm \
+    --name syncthing \
+    -p 8384:8384 -p 22000:22000 \
+    -v syncthing_data:/etc/syncthing \
+    nventiveux/docker-syncthing:latest
+```
+
+Use `/syncedfolders` to store synced content to the syncthing container:
+
+```shell
+$ docker run \
+    --rm \
+    --name syncthing \
+    -p 8384:8384 -p 22000:22000 \
+    -v syncthing_data:/etc/syncthing \
+    -v /work:/syncedfolders/work \
+    nventiveux/docker-syncthing:latest
+```
 
 ## References
 
-Based on [tianon/dockerfiles](https://github.com/tianon/dockerfiles).
+* Inspiration taken from [tianon/dockerfiles](https://github.com/tianon/dockerfiles).

--- a/README.md
+++ b/README.md
@@ -19,10 +19,38 @@ Tested on:
 $ curl -sSL https://raw.githubusercontent.com/nVentiveUX/docker-syncthing/master/installer.sh | sudo bash
 ```
 
+The installer will:
+
 * Ensure [Docker Engine](https://www.docker.com/products/overview) is installed.
-* Install as a **systemd service** container stop / start.
-* Install service options in `/etc/default`.
-* Set service start at boot.
+* Install **docker-syncthing** systemd service for container stop / start.
+* Install service options in `/etc/default/docker-syncthing`.
+
+### Provide content to sync
+
+Path `/syncedfolders` within container holds synced content.
+
+Edit service configuration `/etc/default/docker-syncthing` to specify folder to sync.
+
+Available options:
+
+* `VOLUMES`
+    * Specify your folder(s) to sync here (you can specify more by appending `-v`):
+
+    ```
+    VOLUMES="-v /path/to/your/content:/syncedfolders/content"
+    ```
+
+* `PORTS`
+    * Specify port binding used by Syncthing:
+
+    ```
+    PORTS="-p 8384:8384 -p 22000:22000"
+    ```
+
+    * Default ports:
+        * `21027/udp` --> Local discovery
+        * `22000/tcp` --> Sync protocol
+        * `8384/tcp` --> Admin interface
 
 ## Run multiple instances
 

--- a/installer.sh
+++ b/installer.sh
@@ -3,15 +3,32 @@
 # Easy to use installer script to setup latest stable release of Syncthing in a
 # Docker container.
 #
+# Run it with:
+#
+#   curl -sSL https://raw.githubusercontent.com/nVentiveUX/docker-syncthing/master/installer.sh | sudo bash
+#
 set -euo pipefail
 trap "echo 'ERROR: Script failed: see failed command above.'" ERR
 
 SYNCTHING_IMAGE='nventiveux/docker-syncthing'
-SYNCTHING_RELEASE='0.14.18'
+SYNCTHING_RELEASE='latest'
+
+GITHUB_ROOT='https://raw.githubusercontent.com/nVentiveUX/docker-syncthing/master'
+
+# Used for debugging with:
+#   python3 -m http.server 8080
+#GITHUB_ROOT='http://192.168.1.1:8080'
+
+# Download a file using curl from remote repository
+function repo_file_download() {
+    local src="$1"
+    local dest="$2"
+    curl -sSL "${GITHUB_ROOT}/${src}" -o "${dest}"
+}
 
 # Install Docker Engine
 function install_docker() {
-    if [[ -x docker ]]; then
+    if [[ ! -x "$(which docker)" ]]; then
         echo "## Docker is not found. Installing..."
         ( curl -sSL https://get.docker.com/ | sh )
     fi
@@ -24,12 +41,23 @@ function pull_image() {
 
 function install_systemd_service() {
     echo "## Installing systemd service..."
-    cp -v systemd/docker-syncthing.service /etc/systemd/system/ &&
-    cp -v systemd/docker-syncthing@.default /etc/default/docker-syncthing &&
-    systemctl daemon-reload &&
+    repo_file_download \
+        "systemd/docker-syncthing@.service" \
+        "/etc/systemd/system/docker-syncthing@.service"
+    repo_file_download \
+        "systemd/docker-syncthing.service" \
+        "/etc/systemd/system/docker-syncthing.service"
+
+    if [[ ! -e "/etc/default/docker-syncthing" ]]; then
+        repo_file_download \
+            "systemd/docker-syncthing@.default" \
+            "/etc/default/docker-syncthing"
+    fi
+
+    systemctl daemon-reload
 
     echo "### Enabling docker-syncthing at system boot..."
-    systemctl enable docker-syncthing.service;
+    systemctl enable docker-syncthing.service
 }
 
 function start_syncthing_service() {
@@ -40,10 +68,9 @@ function start_syncthing_service() {
 function configure() {
     echo
     echo "IMPORTANT NOTICE:"
-    echo "   You may now want to provide content to syncthing, please edit /etc/default/docker-syncthing to add volumes."
+    echo "   You may now want to provide content to syncthing, please edit /etc/default/docker-syncthing to configure volumes."
     echo "   Then, restart the service with \"sudo systemctl restart docker-syncthing\" to apply changes."
     echo
-    /etc/default/docker-syncthing
 }
 
 function show_success() {
@@ -56,8 +83,8 @@ function show_success() {
 install_docker
 pull_image
 install_systemd_service
-start_syncthing_service
 configure
+start_syncthing_service
 show_success
 
 exit 0

--- a/installer.sh
+++ b/installer.sh
@@ -55,14 +55,16 @@ function install_systemd_service() {
     fi
 
     systemctl daemon-reload
-
-    echo "### Enabling docker-syncthing at system boot..."
-    systemctl enable docker-syncthing.service
 }
 
 function start_syncthing_service() {
-    echo "## Starting docker-syncthing service..."
-    systemctl start docker-syncthing.service
+    echo
+    echo "Manually start the service with:"
+    echo "  systemctl start docker-syncthing.service"
+    echo
+    echo "Enable service start at boot time with:"
+    echo "  systemctl enable docker-syncthing.service"
+    echo
 }
 
 function configure() {

--- a/installer.sh
+++ b/installer.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# Easy to use installer script to setup latest stable release of Syncthing in a
+# Docker container.
+#
+set -euo pipefail
+trap "echo 'ERROR: Script failed: see failed command above.'" ERR
+
+SYNCTHING_IMAGE='nventiveux/docker-syncthing'
+SYNCTHING_RELEASE='0.14.18'
+
+# Install Docker Engine
+function install_docker() {
+    if [[ -x docker ]]; then
+        echo "## Docker is not found. Installing..."
+        ( curl -sSL https://get.docker.com/ | sh )
+    fi
+}
+
+function pull_image() {
+    echo "## Pulling image \"${SYNCTHING_IMAGE}\"..."
+    docker pull ${SYNCTHING_IMAGE}:${SYNCTHING_RELEASE}
+}
+
+function install_systemd_service() {
+    echo "## Installing systemd service..."
+    cp -v systemd/docker-syncthing.service /etc/systemd/system/ &&
+    cp -v systemd/docker-syncthing@.default /etc/default/docker-syncthing &&
+    systemctl daemon-reload &&
+
+    echo "### Enabling docker-syncthing at system boot..."
+    systemctl enable docker-syncthing.service;
+}
+
+function start_syncthing_service() {
+    echo "## Starting docker-syncthing service..."
+    systemctl start docker-syncthing.service
+}
+
+function configure() {
+    echo
+    echo "IMPORTANT NOTICE:"
+    echo "   You may now want to provide content to syncthing, please edit /etc/default/docker-syncthing to add volumes."
+    echo "   Then, restart the service with \"sudo systemctl restart docker-syncthing\" to apply changes."
+    echo
+    /etc/default/docker-syncthing
+}
+
+function show_success() {
+    echo
+    echo "Done. Installation successfull."
+    echo "Make your browser point to https://localhost:8384/ to configure your syncthing installation."
+}
+
+# Main
+install_docker
+pull_image
+install_systemd_service
+start_syncthing_service
+configure
+show_success
+
+exit 0

--- a/systemd/docker-syncthing.service
+++ b/systemd/docker-syncthing.service
@@ -6,7 +6,7 @@ After=docker.service
 [Service]
 Restart=always
 EnvironmentFile=-/etc/default/docker-syncthing
-ExecStart=/usr/bin/docker run --rm --name syncthing -h %H_syncthing -p 8384:8384 -p 22000:22000 -v syncthing_data:/etc/syncthing $VOLUMES nventiveux/docker-syncthing:0.14.18
+ExecStart=/usr/bin/docker run --rm --name syncthing -h %H_syncthing $PORTS -v syncthing_data:/etc/syncthing $VOLUMES nventiveux/docker-syncthing:latest
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/docker-syncthing.service
+++ b/systemd/docker-syncthing.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Syncthing - Open Source Continuous File Synchronization
+Documentation=http://docs.syncthing.net/
+After=docker.service
+
+[Service]
+Restart=always
+EnvironmentFile=-/etc/default/docker-syncthing
+ExecStart=/usr/bin/docker run --rm --name syncthing -h %H_syncthing -p 8384:8384 -p 22000:22000 -v syncthing_data:/etc/syncthing $VOLUMES nventiveux/docker-syncthing:0.14.18
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/docker-syncthing.service
+++ b/systemd/docker-syncthing.service
@@ -5,6 +5,7 @@ After=docker.service
 
 [Service]
 Restart=always
+Environment='PORTS=-p 8384:8384 -p 22000:22000'
 EnvironmentFile=-/etc/default/docker-syncthing
 ExecStart=/usr/bin/docker run --rm --name syncthing -h %H_syncthing $PORTS -v syncthing_data:/etc/syncthing $VOLUMES nventiveux/docker-syncthing:latest
 

--- a/systemd/docker-syncthing@.default
+++ b/systemd/docker-syncthing@.default
@@ -3,3 +3,6 @@
 # List directories to mount in /syncedfolders from host.
 # Refer to '-v' option of 'docker run' to know the syntax.
 #VOLUMES="-v /media/livestorage/videos/Movies/VF-VOSTFR:/syncedfolders/Movies/VF-VOSTFR"
+
+# Configure ports mapping between host and container
+#PORTS="-p 8384:8384 -p 22000:22000"

--- a/systemd/docker-syncthing@.service
+++ b/systemd/docker-syncthing@.service
@@ -5,8 +5,9 @@ After=docker.service
 
 [Service]
 Restart=always
+Environment='PORTS=-p 8384:8384 -p 22000:22000'
 EnvironmentFile=-/etc/default/docker-syncthing@%i
-ExecStart=/usr/bin/docker run --rm --name syncthing_%i -h %H_syncthing_%i -p 8384:8384 -p 22000:22000 -v syncthing_%i_data:/etc/syncthing $VOLUMES nventiveux/docker-syncthing:0.14.19
+ExecStart=/usr/bin/docker run --rm --name syncthing_%i -h %H_syncthing_%i $PORTS -v syncthing_%i_data:/etc/syncthing $VOLUMES nventiveux/docker-syncthing:latest
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Yo my friend !
Please have a look to this PR that add a `curl | bash` installer as detailed in #5.

I have tested it using Python 3's http module:

```shell
$ python3 -m http.server 8080
```

You need then to adapt the `GITHUB_ROOT` variable in `installer.sh` and launch the installer with:

```shell
$ curl -sSL http://<IP_PYTHON_HOST>:8080/installer.sh | sudo bash
```

## Known issues

* The image pulling is failing because the docker image is not (yet) available on **Docker Hub**.
    * As a workaround, comment call to function `pull_image` in `installer.sh`.

## Notable changes

* I have reworked the README to make use of it.

* We use now `<image>:latest` tag everywhere. This is strongly linked to **master** branch (stable, prod).

* We now have a single instance service in systemd, see `docker-syncthing` service.

* Systemd services have now a new `PORTS` environment variable which permit the redefinition (per instances / single instance) of port mapping between host and container(s).
    * `PORTS` variable is set by default through the service definition `Environment` option. You can override it using `/etc/default/docker-syncthing` (single instance) or `/etc/default/docker-syncthing@<INSTANCE_NAME>` (multiple instances).