### PR TITLE
fix(release): incorrect tag version in tag task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,159 +4,305 @@
 
 All notable changes to this project will be documented in this file.
 
-## v2.0.13 (2026-01-22)
+## 3.0.0 - 2026-02-28
 
-### Feat
+### <!-- 0 -->⬆️ Upstream
 
-- **core**: bump syncthing to 2.0.13
+* **syncthing**: Bump to 2.0.14
 
-## v2.0.11 (2025-11-30)
+  * <https://github.com/syncthing/syncthing/releases/tag/v2.0.14>
 
-### Feat
+### <!-- 1 -->🚀 Features
 
-- **core**: bump syncthing to 2.0.11
+* **core**: Has its own lifecycle from now
 
-## v2.0.10 (2025-10-23)
+  The project's version is not anymore related to syncthing own lifecyle. Check CHANGELOG to know which version of syncthing is embeded in the image.
+* **core**: Harmonize project release
+* **core**: Bump syncthing to 2.0.13
+* **image**: Update base image to alpine:3.23 and improve bump scripts
 
-### Feat
+### <!-- 2 -->🐛 Bug Fixes
 
-- prepare for syncthing v2
+* **release**: Incorrect tag version in tag task
 
-### Fix
+## 2.0.11 - 2025-11-30
 
-- **ci**: login to docker hub in pr
+### <!-- 1 -->🚀 Features
 
-## v1.30.0 (2025-07-15)
+* **core**: Bump syncthing to 2.0.11
 
-### Feat
+## 2.0.10 - 2025-10-23
 
-- **core**: bump syncthing to 1.30.0
+### <!-- 1 -->🚀 Features
 
-## v1.29.6 (2025-05-07)
 
-### Feat
+### <!-- 2 -->🐛 Bug Fixes
 
-- **core**: bump syncthing to 1.29.6
+* **ci**: Login to docker hub in pr
 
-## v1.29.2 (2025-02-18)
+## 1.30.0 - 2025-07-15
 
-### Feat
+### <!-- 1 -->🚀 Features
 
-- **core**: bump syncthing to 1.29.2
+* **core**: Bump syncthing to 1.30.0
 
-## v1.28.1 (2024-12-05)
+## 1.29.6 - 2025-05-07
 
-### Feat
+### <!-- 1 -->🚀 Features
 
-- **core**: bump syncthing to 1.28.1
+* **core**: Bump syncthing to 1.29.6
 
-## v1.27.12 (2024-09-07)
+## 1.29.2 - 2025-02-18
 
-### Feat
+### <!-- 1 -->🚀 Features
 
-- **core**: bump syncthing to 1.27.12
+* **core**: Bump alpine to 3.21
+* **core**: Bump syncthing to 1.29.2
 
-### Fix
+### <!-- 2 -->🐛 Bug Fixes
 
-- **ci**: trigger on master
+* **docker**: Removed signature check for sha256sum.txt.asc
 
-## v1.27.9 (2024-07-04)
+## 1.28.1 - 2024-12-05
 
-### Feat
+### <!-- 1 -->🚀 Features
 
-- **core**: bump syncthing to 1.27.9
+* **core**: Bump syncthing to 1.28.1
 
-## v1.27.6 (2024-04-11)
+## 1.27.12 - 2024-09-07
 
-### Feat
+### <!-- 1 -->🚀 Features
 
-- **core**: bump syncthing to 1.27.6
+* **core**: Bump syncthing to 1.27.12
 
-## v1.27.5 (2024-04-07)
+### <!-- 2 -->🐛 Bug Fixes
 
-### Feat
+* **ci**: Manual release for the moment
+* **ci**: Trigger on master
 
-- **core**: bump syncthing to 1.27.5
+## 1.27.9 - 2024-07-04
 
-## v1.27.4 (2024-03-24)
+### <!-- 1 -->🚀 Features
 
-### Feat
+* **core**: Bump syncthing to 1.27.9
 
-- **core**: bump syncthing to 1.27.4
-- **dev**: move from `poetry` to `rye`
+## 1.27.6 - 2024-04-11
 
-## v1.27.2 (2024-01-04)
+### <!-- 1 -->🚀 Features
 
-### Feat
+* **core**: Bump syncthing to 1.27.6
 
-- **core**: bump syncthing to 1.27.2
+    See [official release](https://github.com/syncthing/syncthing/releases/tag/v1.27.6).
 
-## v1.26.1 (2023-11-24)
+## 1.27.5 - 2024-04-07
 
-### Feat
+### <!-- 1 -->🚀 Features
 
-- **core**: bump syncthing to 1.26.1
+* **core**: Bump syncthing to 1.27.5
 
-## v1.25.0 (2023-10-05)
+    See [official release](https://github.com/syncthing/syncthing/releases/tag/v1.27.5).
 
-### Feat
+## 1.27.4 - 2024-03-24
 
-- **core**: bump syncthing to 1.25.0
+### <!-- 1 -->🚀 Features
 
-## v1.24.0 (2023-09-24)
+* **core**: Bump syncthing to 1.27.4
 
-### Feat
+    See [official release](https://github.com/syncthing/syncthing/releases/tag/v1.27.4).
+* **dev**: Move from `poetry` to `rye`
 
-- **core**: bump syncthing to 1.24.0
+## 1.27.2 - 2024-01-04
 
-## v1.23.7 (2023-08-22)
+### <!-- 1 -->🚀 Features
 
-### Feat
+* **core**: Bump syncthing to 1.27.2
 
-- **core**: bump syncthing to 1.23.7
+    See [official release](https://github.com/syncthing/syncthing/releases/tag/v1.27.2).
 
-## v1.23.5 (2023-06-11)
+## 1.26.1 - 2023-11-24
 
-### Feat
+### <!-- 1 -->🚀 Features
 
-- **core**: bump syncthing to 1.23.5
+* **core**: Bump syncthing to 1.26.1
 
-## v1.23.4 (2023-04-10)
+    See [official release](https://github.com/syncthing/syncthing/releases/tag/v1.26.1).
 
-### Feat
+## 1.25.0 - 2023-10-05
 
-- **core**: bump syncthing to 1.23.4
+### <!-- 1 -->🚀 Features
 
-## v1.23.2 (2023-03-10)
+* **core**: Bump syncthing to 1.25.0
 
-### Feat
+    See [official release](https://github.com/syncthing/syncthing/releases/tag/v1.25.0).
 
-- **core**: bump syncthing to v1.23.2
+## 1.24.0 - 2023-09-24
 
-## v1.23.1 (2023-02-10)
+### <!-- 1 -->🚀 Features
 
-### Feat
+* **core**: Bump syncthing to 1.24.0
 
-- **core**: bump syncthing to v1.23.1
-- **ci**: auto create a release for tags
+## 1.23.7 - 2023-08-22
 
-## v1.23.0 (2023-02-03)
+### <!-- 1 -->🚀 Features
 
-### Feat
+* **core**: Bump syncthing to 1.23.7
 
-- bump syncthing to v1.23.0
+## 1.23.5 - 2023-06-11
 
-## v1.22.2 (2022-12-07)
+### <!-- 1 -->🚀 Features
 
-### Feat
+* **core**: Bump syncthing to 1.23.5
 
-- **ci**: add post releases in image tags
-- **core**: bump syncthing to 1.22.2
-- **release**: add a changelog
-- **release**: move to `commitizen`
+## 1.23.4 - 2023-04-10
 
-## v1.22.1-0 (2022-11-27)
+### <!-- 1 -->🚀 Features
 
-### Feat
+* **core**: Bump syncthing to 1.23.4
 
-- **ci**: switch to multiarch images
+## 1.23.2 - 2023-03-10
+
+### <!-- 1 -->🚀 Features
+
+* **core**: Bump syncthing to v1.23.2
+
+## 1.23.1 - 2023-02-10
+
+### <!-- 1 -->🚀 Features
+
+* **ci**: Auto create a release for tags
+* **core**: Bump syncthing to v1.23.1
+
+## 1.23.0 - 2023-02-03
+
+### <!-- 1 -->🚀 Features
+
+
+### <!-- 3 -->📚 Documentation
+
+
+## 1.22.2 - 2022-12-07
+
+### <!-- 1 -->🚀 Features
+
+* **ci**: Add post releases in image tags
+* **core**: Bump syncthing to 1.22.2
+* **release**: Add a changelog
+* **release**: Move to `commitizen`
+
+## 1.22.1-0 - 2022-11-27
+
+### <!-- 1 -->🚀 Features
+
+* **ci**: Switch to multiarch images
+
+## 1.20.1-0 - 2022-05-22
+
+### <!-- 1 -->🚀 Features
+
+
+## 1.19.1-0 - 2022-03-04
+
+### <!-- 1 -->🚀 Features
+
+* **config**: Update schema to v36
+
+### <!-- 7 -->🧪 Testing
+
+
+## 1.18.5-0 - 2021-12-07
+
+### <!-- 1 -->🚀 Features
+
+
+## 1.17.0-1 - 2021-06-30
+
+### <!-- 1 -->🚀 Features
+
+* **ci**: Migrate to github actions
+
+### <!-- 2 -->🐛 Bug Fixes
+
+* **ci**: Missing source image in docker tag
+* **ci**: Image_tag ➞ image-tag
+* **ci**: Wrong quote in if expression
+* **ci**: Sks pgp keyservers are gone
+* **ci**: Update new gpg syncthing release keys
+
+## 1.15.1-0 - 2021-04-06
+
+### Config
+
+
+## 1.9.0-0 - 2020-09-10
+
+### Config
+
+
+## 1.7.1-0 - 2020-07-14
+
+### Config
+
+
+### Project
+
+
+### Readme
+
+
+## 1.5.0-2 - 2020-05-10
+
+### Entrypoint
+
+
+## 1.4.1-0 - 2020-04-06
+
+### Config
+
+
+## 1.3.1-0 - 2019-11-05
+
+### <!-- 1 -->🚀 Features
+
+* **ci**: Script to push images
+* **ci**: Use scripts to build images
+
+### <!-- 2 -->🐛 Bug Fixes
+
+* **ci**: Search for QEMU_VERSION in environment
+* **ci**: Invalid detecttion for ARCH
+
+## 1.3.0-0 - 2019-10-06
+
+### <!-- 2 -->🐛 Bug Fixes
+
+* **bumpversion**: Bump all Dockerfiles
+
+## 1.2.1-0 - 2019-08-06
+
+### <!-- 1 -->🚀 Features
+
+* **core**: Upgrade syncthing to v1.2.1
+
+## 1.2.0-0 - 2019-07-13
+
+### <!-- 0 -->⬆️ Upstream
+
+* **syncthing**: Disable relaying by default
+* **syncthing**: Disable global announce by default
+
+### <!-- 1 -->🚀 Features
+
+* **Dockerfiles**: Templates used for Dockerfiles
+* **README**: Add build status
+* **README**: Refresh and refactor README
+* **ci**: Tag image using git tags for versioning
+* **ci**: Use travis to build / push images
+* **init**: Allow to specify user UID/GID
+
+### <!-- 2 -->🐛 Bug Fixes
+
+* **ci**: Refresh secure tokens
+* **config**: Local announces are disabled by default
+* **rootfs**: Rootfs is root of filesystem
+
+## 0.1.0 - 2017-01-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
+<!-- markdownlint-disable MD024 -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v2.0.13 (2026-01-22)
 

--- a/README.md
+++ b/README.md
@@ -111,14 +111,20 @@ Commit changes and submit a **Pull Request**.
 
 Update `SYNCTHING_VERSION` in `Taskfile.yml`.
 
-Bump the version using:
+Bump syncthing version using:
 
 ```sh
 git switch -c release/next
-task bump
+task bump:syncthing
 # Open a pull request
 # Tests...
-# Merge
+```
+
+Bump project's version:
+
+```sh
+task bump
+# Merge pull request
 # Delete release/next
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,11 @@ vars:
 
 tasks:
   bump:
+    desc: "Bump project's version"
+    cmds:
+      - scripts/bump.sh
+
+  bump:syncthing:
     desc: "Bump syncthing version"
     cmds:
       - scripts/bump-syncthing.sh {{.SYNCTHING_VERSION}}

--- a/cliff.toml
+++ b/cliff.toml
@@ -76,6 +76,7 @@ commit_parsers = [
     { message = "^style", group = "<!-- 6 -->🎨 Styling" },
     { message = "^test", group = "<!-- 7 -->🧪 Testing" },
     { message = "^chore", skip = true },
+    { message = "^bump", skip = true },
     { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
     { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
     { message = "^Merge pull request", skip = true },

--- a/scripts/tag.sh
+++ b/scripts/tag.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-next_version="${1:?Usage: $0 <next_version>}"
+next_version="$(git cliff --bumped-version)"
 
 # Checks
 if [[ -n $(git status --porcelain) ]]


### PR DESCRIPTION
## 3.0.0 - 2026-02-28

### <!-- 0 -->⬆️ Upstream

* **syncthing**: Bump to 2.0.14

  * <https://github.com/syncthing/syncthing/releases/tag/v2.0.14>

### <!-- 1 -->🚀 Features

* **core**: Has its own lifecycle from now

  The project's version is not anymore related to syncthing own lifecyle. Check CHANGELOG to know which version of syncthing is embeded in the image.
* **core**: Harmonize project release
* **image**: Update base image to alpine:3.23 and improve bump scripts

### <!-- 2 -->🐛 Bug Fixes

* **release**: Incorrect tag version in tag task