### PR TITLE
Prepare release v3.2.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-task 3.48.0
-git-cliff 2.12.0
+task 3.51.1
+git-cliff 2.13.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## 3.2.0 - 2026-06-09
+
+### <!-- 0 -->⬆️ Upstream
+
+* **syncthing**: Bump to 2.1.1
+
+  * [Release notes](https://github.com/syncthing/syncthing/releases/tag/v2.1.1)
+
+### <!-- 1 -->🚀 Features
+
+* **config**: Bump config version schema to 52
+
+### <!-- 2 -->🐛 Bug Fixes
+
+* **tests**: Allow to select image tag in `tests` task
+
 ## 3.1.0 - 2026-03-03
 
 ### <!-- 0 -->⬆️ Upstream

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV SYNCTHING_USER="syncthing" \
     SYNCTHING_GROUP="syncthing" \
     SYNCTHING_GROUP_GID=1000 \
     SYNCTHING_ADMIN_USER="admin" \
-    SYNCTHING_VERSION="2.0.15" \
+    SYNCTHING_VERSION="2.1.1" \
     SYNCTHING_ARCH="amd64"
 
 RUN set -x \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM alpine:3.23
+FROM alpine:3.23.4
 
 LABEL authors="nVentiveUX <https://github.com/nVentiveUX>"
 LABEL license="MIT"
-LABEL description="Docker image for syncthing installation. \
-Think for ARM / x64 devices."
+LABEL description="Docker image for syncthing installation. Think for ARM / x64 devices."
 
 SHELL [ "/bin/ash", "-eo", "pipefail", "-c" ]
 
@@ -17,26 +16,26 @@ ENV SYNCTHING_USER="syncthing" \
     SYNCTHING_ARCH="amd64"
 
 RUN set -x \
-  && apk add --no-cache \
+    && apk add --no-cache \
     bash \
     coreutils \
     py3-bcrypt \
     py3-cryptography \
     shadow \
     su-exec \
-  && tarball="syncthing-linux-${SYNCTHING_ARCH}-v${SYNCTHING_VERSION}.tar.gz" \
-  && wget --quiet \
+    && tarball="syncthing-linux-${SYNCTHING_ARCH}-v${SYNCTHING_VERSION}.tar.gz" \
+    && wget --quiet \
     "https://github.com/syncthing/syncthing/releases/download/v${SYNCTHING_VERSION}/$tarball" \
     "https://github.com/syncthing/syncthing/releases/download/v${SYNCTHING_VERSION}/sha256sum.txt.asc" \
-  && grep -E " ${tarball}\$" sha256sum.txt.asc | sha256sum -c - \
-  && rm -rf "$GNUPGHOME" sha256sum.txt.asc \
-  && dir="$(basename "$tarball" .tar.gz)" \
-  && bin="$dir/syncthing" \
-  && tar -xvzf "$tarball" "$bin" \
-  && rm "$tarball" \
-  && mv "$bin" /usr/local/bin/syncthing \
-  && rmdir "$dir" \
-  && mkdir -p /etc/syncthing /var/lib/syncthing
+    && grep -E " ${tarball}\$" sha256sum.txt.asc | sha256sum -c - \
+    && rm -rf "$GNUPGHOME" sha256sum.txt.asc \
+    && dir="$(basename "$tarball" .tar.gz)" \
+    && bin="$dir/syncthing" \
+    && tar -xvzf "$tarball" "$bin" \
+    && rm "$tarball" \
+    && mv "$bin" /usr/local/bin/syncthing \
+    && rmdir "$dir" \
+    && mkdir -p /etc/syncthing /var/lib/syncthing
 
 COPY rootfs/ /
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Following arch are missing tests:
 ## Available image tags
 
 * [nventiveux/syncthing](https://hub.docker.com/r/nventiveux/syncthing)
-  * Image version: `latest`, `3.1.0` ([Dockerfile](./Dockerfile))
+  * Image version: `latest`, `3.2.0` ([Dockerfile](./Dockerfile))
   * Syncthing version: `v2.1.1`
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Following arch are missing tests:
 
 * [nventiveux/syncthing](https://hub.docker.com/r/nventiveux/syncthing)
   * Image version: `latest`, `3.1.0` ([Dockerfile](./Dockerfile))
-  * Syncthing version: `v2.0.15`
+  * Syncthing version: `v2.1.1`
 
 ## Usage
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 
 silent: true
 
@@ -31,7 +31,9 @@ tasks:
   tests:
     desc: "Build and run the container for testing"
     cmds:
-      - docker run -it --rm -p 8000:8384 --name syncthing_tests {{.DOCKER_IMAGE}}:latest
+      - docker run -it --rm -p 8000:8384 --name syncthing_tests {{.DOCKER_IMAGE}}:{{.DOCKER_TAG}}
+    requires:
+      vars: [DOCKER_IMAGE, DOCKER_TAG]
 
   clean:
     desc: "Remove the local docker image"

--- a/rootfs/docker-entrypoint.sh
+++ b/rootfs/docker-entrypoint.sh
@@ -24,7 +24,7 @@ get_ownerships() {
     fi
 }
 
-printf "* Generated salted password: %s\\n" "${SYNCTHING_ADMIN_PASSWORD_HASH}"
+printf "* Generated salted password: %s\\n" "${SYNCTHING_ADMIN_PASSWORD_HASH:0:8}..."
 
 if ! getent passwd "${SYNCTHING_USER}" &>/dev/null
 then

--- a/rootfs/etc/syncthing/config.xml
+++ b/rootfs/etc/syncthing/config.xml
@@ -1,4 +1,4 @@
-<configuration version="51">
+<configuration version="52">
     <gui enabled="true" tls="true" debugging="false">
         <address>0.0.0.0:8384</address>
         <authMode>static</authMode>


### PR DESCRIPTION
## 3.2.0 - 2026-06-09

### <!-- 0 -->⬆️ Upstream

* **syncthing**: Bump to 2.1.1

  * [Release notes](https://github.com/syncthing/syncthing/releases/tag/v2.1.1)

### <!-- 1 -->🚀 Features

* **config**: Bump config version schema to 52

### <!-- 2 -->🐛 Bug Fixes

* **tests**: Allow to select image tag in `tests` task